### PR TITLE
feat: add settings sign out option

### DIFF
--- a/client/src/app/index.tsx
+++ b/client/src/app/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Animated, DimensionValue, Pressable, Text, View } from 'react-native';
+import { Animated, Pressable, Text, View } from 'react-native';
 import { RotateCcw, RotateCw } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 

--- a/client/src/app/index.tsx
+++ b/client/src/app/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Animated, DimensionValue, Pressable, Text, View } from 'react-native';
 import { RotateCcw, RotateCw } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
 
 import { indexStyles } from '@/styles/indexScreen';
 import { SettingsButton } from '@/components/SettingsButton';
@@ -8,7 +9,7 @@ import { useTheme } from '@/hooks/use-theme';
 import { AudioInformationBoard } from '@/components/AudioInformationBoard';
 import { AudioData } from '@/types/audio';
 import { CARDS } from '@/types/cards';
-import { getUserSession } from '@/utils/storage';
+import { clearUserSession, getUserSession } from '@/utils/storage';
 import { UserProfile } from '@/types/user';
 import { PlayToggleButton } from '@/components/PlayToggleButton';
 import { ProgressBar } from '@/components/ProgressBar';
@@ -17,6 +18,7 @@ type ContentKey = 'music' | 'podcast';
 
 export default function App() {
   const theme = useTheme();
+  const router = useRouter();
   
   // --- STATE: UI & Navigation ---
   const [activeCardIndex, setActiveCardIndex] = useState<number>(
@@ -24,6 +26,7 @@ export default function App() {
   );
   const swapProgress = useRef(new Animated.Value(0)).current;
   const [loading, setLoading] = useState(true);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   // --- STATE: User & Session ---
   const [userId, setUserId] = useState<number | null>(null);
@@ -85,6 +88,16 @@ export default function App() {
   const handleCardPress = () => {
     if (isDraggingSlider) return; 
     setActiveCardIndex((prev) => (prev + 1) % CARDS.length);
+    setIsSettingsOpen(false);
+  };
+
+  const handleSignOut = async () => {
+    await clearUserSession('userId');
+    setUserId(null);
+    setUserProfile(null);
+    setIsSettingsOpen(false);
+    setIsPlaying(false);
+    router.replace('/sign_in');
   };
 
   // --- EFFECTS ---
@@ -310,7 +323,27 @@ export default function App() {
           })}
         </View>
       </View>
-      <SettingsButton style={indexStyles.settingsButton} backgroundColor={theme.backgroundSelected} textColor={theme.textSecondary} />
+      <View style={indexStyles.settingsMenuAnchor}>
+        <SettingsButton
+          style={indexStyles.settingsButton}
+          backgroundColor={theme.backgroundSelected}
+          textColor={theme.textSecondary}
+          onPress={() => setIsSettingsOpen((prev) => !prev)}
+        />
+        {isSettingsOpen && (
+          <View style={[indexStyles.settingsDropdown, { backgroundColor: theme.backgroundSelected }]}>
+            <Pressable
+              onPress={handleSignOut}
+              style={indexStyles.settingsDropdownItem}
+              accessibilityLabel="Sign out"
+            >
+              <Text style={[indexStyles.settingsDropdownText, { color: theme.text }]}>
+                Sign out
+              </Text>
+            </Pressable>
+          </View>
+        )}
+      </View>
     </View>
   );
 }

--- a/client/src/styles/cornerButton.ts
+++ b/client/src/styles/cornerButton.ts
@@ -1,10 +1,12 @@
 import { StyleSheet } from 'react-native';
 
+export const CORNER_BUTTON_SIZE = 64;
+
 export const cornerButtonStyles = StyleSheet.create({
   base: {
     position: 'absolute',
-    width: 64,
-    height: 64,
+    width: CORNER_BUTTON_SIZE,
+    height: CORNER_BUTTON_SIZE,
     borderRadius: 999,
     alignItems: 'center',
     justifyContent: 'center',

--- a/client/src/styles/indexScreen.ts
+++ b/client/src/styles/indexScreen.ts
@@ -3,7 +3,8 @@ import { StyleSheet } from 'react-native';
 import { Spacing } from '@/constants/theme';
 import { CORNER_BUTTON_SIZE } from '@/styles/cornerButton';
 
-const SETTINGS_DROPDOWN_TOP_OFFSET = CORNER_BUTTON_SIZE - (Spacing.one + Spacing.half);
+const SETTINGS_DROPDOWN_BUTTON_OVERLAP = Spacing.one + Spacing.half;
+const SETTINGS_DROPDOWN_TOP_OFFSET = CORNER_BUTTON_SIZE - SETTINGS_DROPDOWN_BUTTON_OVERLAP;
 
 export const indexStyles = StyleSheet.create({
   screen: {

--- a/client/src/styles/indexScreen.ts
+++ b/client/src/styles/indexScreen.ts
@@ -235,6 +235,37 @@ export const indexStyles = StyleSheet.create({
     top: Spacing.four,
     right: Spacing.four,
   },
+  settingsMenuAnchor: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    zIndex: 20,
+    alignItems: 'flex-end',
+  },
+  settingsDropdown: {
+    position: 'absolute',
+    top: Spacing.four + 58,
+    right: Spacing.four,
+    minWidth: 128,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.18)',
+    overflow: 'hidden',
+    shadowColor: '#08131E',
+    shadowOpacity: 0.18,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 8 },
+  },
+  settingsDropdownItem: {
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.three,
+  },
+  settingsDropdownText: {
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
 
   playbackContainer: {
   marginTop: 'auto', // Pushes the whole block to the bottom of the card

--- a/client/src/styles/indexScreen.ts
+++ b/client/src/styles/indexScreen.ts
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import { Spacing } from '@/constants/theme';
+import { CORNER_BUTTON_SIZE } from '@/styles/cornerButton';
 
 export const indexStyles = StyleSheet.create({
   screen: {
@@ -244,7 +245,7 @@ export const indexStyles = StyleSheet.create({
   },
   settingsDropdown: {
     position: 'absolute',
-    top: Spacing.four + 58,
+    top: Spacing.four + CORNER_BUTTON_SIZE,
     right: Spacing.four,
     minWidth: 128,
     borderRadius: 16,

--- a/client/src/styles/indexScreen.ts
+++ b/client/src/styles/indexScreen.ts
@@ -3,6 +3,8 @@ import { StyleSheet } from 'react-native';
 import { Spacing } from '@/constants/theme';
 import { CORNER_BUTTON_SIZE } from '@/styles/cornerButton';
 
+const SETTINGS_DROPDOWN_TOP_OFFSET = CORNER_BUTTON_SIZE - (Spacing.one + Spacing.half);
+
 export const indexStyles = StyleSheet.create({
   screen: {
     flex: 1,
@@ -245,7 +247,7 @@ export const indexStyles = StyleSheet.create({
   },
   settingsDropdown: {
     position: 'absolute',
-    top: Spacing.four + CORNER_BUTTON_SIZE,
+    top: Spacing.four + SETTINGS_DROPDOWN_TOP_OFFSET,
     right: Spacing.four,
     minWidth: 128,
     borderRadius: 16,

--- a/client/src/styles/indexScreen.ts
+++ b/client/src/styles/indexScreen.ts
@@ -3,8 +3,8 @@ import { StyleSheet } from 'react-native';
 import { Spacing } from '@/constants/theme';
 import { CORNER_BUTTON_SIZE } from '@/styles/cornerButton';
 
-const SETTINGS_DROPDOWN_BUTTON_OVERLAP = Spacing.one + Spacing.half;
-const SETTINGS_DROPDOWN_TOP_OFFSET = CORNER_BUTTON_SIZE - SETTINGS_DROPDOWN_BUTTON_OVERLAP;
+const SETTINGS_DROPDOWN_OVERLAP_WITH_BUTTON = Spacing.one + Spacing.half;
+const SETTINGS_DROPDOWN_TOP_OFFSET = CORNER_BUTTON_SIZE - SETTINGS_DROPDOWN_OVERLAP_WITH_BUTTON;
 
 export const indexStyles = StyleSheet.create({
   screen: {


### PR DESCRIPTION
## Summary
- Add a Settings dropdown on the main screen
- Add a Sign out option under Settings
- Clear local user session and redirect to sign in after sign out

## Testing
- Verified Settings opens the dropdown
- Verified Sign out redirects to `/sign_in`
