### PR TITLE
feat: Updated signin/signup feature & add user information encryptionBrian

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Ensure you have the following installed:
 2. Create a file named `application-local.properties` (`application-local.properties.example` is provided).
 3. Replace `provided_email_username` and `provided_email_password` with your username and password provided on our Discord server.
 
+## Encryption Key Setup
+1. Navigate to: `server/src/main/resources/`.
+2. Create a file named `application-local.properties` (`application-local.properties.example` is provided).
+3. Replace `provided_key` with the key provided on our Discord server.
+
 ***Please make sure you configure database and spring email setups first before setting up your frontend and backend, otherwise the application will fail to run.***
 
 ## Backend Configuration

--- a/client/src/components/signin.tsx
+++ b/client/src/components/signin.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import {
   StyleSheet,
   Text,
@@ -15,29 +15,111 @@ import { saveUserSession } from '@/utils/storage';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+type Step = 'email' | 'otp';
+
 interface SignInScreenProps {
   onNavigateToSignUp?: () => void;
 }
 
 // ─── API ──────────────────────────────────────────────────────────────────────
 
-async function signIn(email: string): Promise<{
-  success: boolean;
-  message: string;
-  redirect: string | null;
-  userId?: number;
-}> {
+async function sendOtp(email: string): Promise<{ success: boolean; message: string }> {
   try {
-    const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/api/auth/sign-in`, {
+    const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/api/auth/send-otp`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email }),
     });
     return await response.json();
   } catch {
+    return { success: false, message: 'Could not reach the server. Please try again.' };
+  }
+}
+
+async function verifyOtp(email: string, otp: string): Promise<{
+  success: boolean;
+  message: string;
+  redirect: string | null;
+  userId?: number;
+}> {
+  try {
+    const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/api/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, otp }),
+    });
+    return await response.json();
+  } catch {
     return { success: false, message: 'Could not reach the server. Please try again.', redirect: null };
   }
 }
+
+// ─── OTP Input ────────────────────────────────────────────────────────────────
+
+interface OtpInputProps {
+  value: string;
+  onChange: (val: string) => void;
+  borderColor: string;
+  textColor: string;
+}
+
+function OtpInput({ value, onChange, borderColor, textColor }: OtpInputProps) {
+  const inputRef = useRef<TextInput>(null);
+  const digits = value.padEnd(6, ' ').split('');
+
+  return (
+    <TouchableOpacity
+      activeOpacity={1}
+      onPress={() => inputRef.current?.focus()}
+      accessibilityLabel="OTP input"
+    >
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChangeText={text => onChange(text.replace(/\D/g, '').slice(0, 6))}
+        keyboardType="numeric"
+        maxLength={6}
+        style={otpStyles.hiddenInput}
+        caretHidden
+      />
+      <View style={otpStyles.row}>
+        {digits.map((digit, i) => (
+          <View
+            key={i}
+            style={[
+              otpStyles.cell,
+              {
+                borderColor: i === value.length ? 'rgba(0,0,0,0.4)' : borderColor,
+                backgroundColor: 'rgba(0,0,0,0.04)',
+              },
+            ]}
+          >
+            <Text style={[otpStyles.cellText, { color: textColor }]}>
+              {digit.trim() || ''}
+            </Text>
+            {i === value.length && (
+              <View style={[otpStyles.cursor, { backgroundColor: textColor }]} />
+            )}
+          </View>
+        ))}
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const otpStyles = StyleSheet.create({
+  hiddenInput: { position: 'absolute', opacity: 0, width: 1, height: 1 },
+  row: { flexDirection: 'row', gap: 10, justifyContent: 'center' },
+  cell: {
+    width: 46, height: 56, borderRadius: 12,
+    borderWidth: 1, alignItems: 'center', justifyContent: 'center',
+  },
+  cellText: { fontSize: 22, fontWeight: '700' },
+  cursor: {
+    position: 'absolute', bottom: 10, width: 2,
+    height: 20, borderRadius: 1, opacity: 0.7,
+  },
+});
 
 // ─── Glass Input ──────────────────────────────────────────────────────────────
 
@@ -50,11 +132,12 @@ interface GlassInputProps {
   textColor: string;
   placeholderColor: string;
   labelColor: string;
+  editable?: boolean;
 }
 
 function GlassInput({
   label, value, onChangeText, placeholder,
-  borderColor, textColor, placeholderColor, labelColor,
+  borderColor, textColor, placeholderColor, labelColor, editable = true,
 }: GlassInputProps) {
   const [focused, setFocused] = useState(false);
 
@@ -63,7 +146,10 @@ function GlassInput({
       <Text style={[inputStyles.label, { color: labelColor }]}>{label}</Text>
       <View style={[
         inputStyles.inputContainer,
-        { borderColor: focused ? 'rgba(0,0,0,0.4)' : borderColor },
+        {
+          borderColor: focused ? 'rgba(0,0,0,0.4)' : borderColor,
+          opacity: editable ? 1 : 0.55,
+        },
       ]}>
         <TextInput
           style={[
@@ -77,6 +163,7 @@ function GlassInput({
           placeholderTextColor={placeholderColor}
           keyboardType="email-address"
           autoCapitalize="none"
+          editable={editable}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
           selectionColor="transparent"
@@ -104,7 +191,9 @@ export default function SignInScreen({ onNavigateToSignUp }: SignInScreenProps) 
   const theme = useTheme();
   const router = useRouter();
 
+  const [step, setStep] = useState<Step>('email');
   const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
   const [loading, setLoading] = useState(false);
   const [statusMessage, setStatusMessage] = useState('');
   const [isError, setIsError] = useState(false);
@@ -112,7 +201,7 @@ export default function SignInScreen({ onNavigateToSignUp }: SignInScreenProps) 
   const placeholderColor = 'rgba(0,0,0,0.25)';
   const labelColor = 'rgba(0,0,0,0.6)';
 
-  const handleSignIn = async () => {
+  const handleSendOtp = async () => {
     if (!email.trim()) {
       setIsError(true);
       setStatusMessage('Please enter your email.');
@@ -120,14 +209,29 @@ export default function SignInScreen({ onNavigateToSignUp }: SignInScreenProps) 
     }
     setLoading(true);
     setIsError(false);
-    setStatusMessage('Signing in…');
-    const result = await signIn(email.trim());
+    setStatusMessage('Sending OTP…');
+    const result = await sendOtp(email.trim());
+    setLoading(false);
+    setIsError(!result.success);
+    setStatusMessage(result.message);
+    if (result.success) setStep('otp');
+  };
+
+  const handleVerifyOtp = async () => {
+    if (otp.length < 6) {
+      setIsError(true);
+      setStatusMessage('Please enter the 6-digit OTP.');
+      return;
+    }
+    setLoading(true);
+    setIsError(false);
+    setStatusMessage('Verifying…');
+    const result = await verifyOtp(email.trim(), otp);
     setLoading(false);
     setIsError(!result.success);
     setStatusMessage(result.message);
 
     if (result.success) {
-      // Save userId to session if provided
       if (result.userId) {
         await saveUserSession('userId', String(result.userId));
       }
@@ -137,6 +241,13 @@ export default function SignInScreen({ onNavigateToSignUp }: SignInScreenProps) 
         router.replace('/');
       }
     }
+  };
+
+  const handleBack = () => {
+    setStep('email');
+    setOtp('');
+    setStatusMessage('');
+    setIsError(false);
   };
 
   return (
@@ -158,33 +269,83 @@ export default function SignInScreen({ onNavigateToSignUp }: SignInScreenProps) 
 
         {/* Single glass card */}
         <View style={[styles.glassCard, { borderColor: theme.backgroundSelected }]}>
-          <GlassInput
-            label="Email"
-            value={email}
-            onChangeText={setEmail}
-            placeholder="example@gmail.com"
-            borderColor={theme.backgroundSelected}
-            textColor={theme.text}
-            placeholderColor={placeholderColor}
-            labelColor={labelColor}
-          />
+          {step === 'email' ? (
+            <>
+              <GlassInput
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+                placeholder="example@gmail.com"
+                borderColor={theme.backgroundSelected}
+                textColor={theme.text}
+                placeholderColor={placeholderColor}
+                labelColor={labelColor}
+              />
 
-          {statusMessage !== '' && (
-            <Text style={[styles.statusText, { color: isError ? '#E53E3E' : '#38A169' }]}>
-              {statusMessage}
-            </Text>
+              {statusMessage !== '' && (
+                <Text style={[styles.statusText, { color: isError ? '#E53E3E' : '#38A169' }]}>
+                  {statusMessage}
+                </Text>
+              )}
+
+              <TouchableOpacity
+                style={[styles.ctaButton, { opacity: loading ? 0.6 : 1 }]}
+                onPress={handleSendOtp}
+                disabled={loading}
+                accessibilityLabel="Send OTP button"
+              >
+                <Text style={styles.ctaText}>
+                  {loading ? 'Sending…' : 'Send OTP →'}
+                </Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              <GlassInput
+                label="Email"
+                value={email}
+                onChangeText={() => {}}
+                borderColor={theme.backgroundSelected}
+                textColor={theme.text}
+                placeholderColor={placeholderColor}
+                labelColor={labelColor}
+                editable={false}
+              />
+
+              <View style={styles.otpSection}>
+                <Text style={[inputStyles.label, { color: labelColor }]}>One-Time Password</Text>
+                <OtpInput
+                  value={otp}
+                  onChange={setOtp}
+                  borderColor={theme.backgroundSelected}
+                  textColor={theme.text}
+                />
+              </View>
+
+              {statusMessage !== '' && (
+                <Text style={[styles.statusText, { color: isError ? '#E53E3E' : '#38A169' }]}>
+                  {statusMessage}
+                </Text>
+              )}
+
+              <TouchableOpacity
+                style={[styles.ctaButton, { opacity: loading ? 0.6 : 1 }]}
+                onPress={handleVerifyOtp}
+                disabled={loading}
+                accessibilityLabel="Verify OTP and sign in"
+              >
+                <Text style={styles.ctaText}>
+                  {loading ? 'Verifying…' : 'Sign In →'}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity onPress={handleBack} accessibilityLabel="Back to email step">
+                <Text style={[styles.linkText, { color: theme.textSecondary }]}>
+                  ← Use a different email
+                </Text>
+              </TouchableOpacity>
+            </>
           )}
-
-          <TouchableOpacity
-            style={[styles.ctaButton, { opacity: loading ? 0.6 : 1 }]}
-            onPress={handleSignIn}
-            disabled={loading}
-            accessibilityLabel="Sign in button"
-          >
-            <Text style={styles.ctaText}>
-              {loading ? 'Signing in…' : 'Sign In →'}
-            </Text>
-          </TouchableOpacity>
         </View>
 
         {/* Footer */}
@@ -232,12 +393,14 @@ const styles = StyleSheet.create({
     shadowRadius: 24, shadowOffset: { width: 0, height: 12 },
     maxWidth: 600, width: '100%', alignSelf: 'center',
   },
+  otpSection: { gap: Spacing.two },
   statusText: { fontSize: 12, textAlign: 'center' },
   ctaButton: {
     borderRadius: 14, paddingVertical: 16,
     alignItems: 'center', backgroundColor: '#2D6BE4',
   },
   ctaText: { fontSize: 15, fontWeight: '700', letterSpacing: 0.4, color: '#FFFFFF' },
+  linkText: { fontSize: 12, textAlign: 'center' },
   footer: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center' },
   footerText: { fontSize: 13 },
   footerLink: { fontSize: 13, fontWeight: '700' },

--- a/client/src/components/signup.tsx
+++ b/client/src/components/signup.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import {
   StyleSheet,
   Text,

--- a/client/src/components/signup.tsx
+++ b/client/src/components/signup.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   StyleSheet,
   Text,
@@ -8,6 +8,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
+  AppState,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTheme } from '@/hooks/use-theme';
@@ -15,7 +16,7 @@ import { Spacing } from '@/constants/theme';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type Step = 'form' | 'otp';
+type Step = 'form' | 'otp' | 'continue';
 
 interface SignUpForm {
   firstName: string;
@@ -30,7 +31,11 @@ interface SignUpScreenProps {
 
 // ─── API calls ────────────────────────────────────────────────────────────────
 
-async function registerUser(form: SignUpForm): Promise<{ success: boolean; message: string }> {
+async function registerUser(form: SignUpForm): Promise<{
+  success: boolean;
+  message: string;
+  userId?: number;
+}> {
   try {
     const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/api/auth/register`, {
       method: 'POST',
@@ -211,6 +216,7 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
   const [loading, setLoading] = useState(false);
   const [statusMessage, setStatusMessage] = useState('');
   const [isError, setIsError] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState('');
 
   const placeholderColor = 'rgba(0,0,0,0.25)';
   const labelColor = 'rgba(0,0,0,0.6)';
@@ -218,7 +224,7 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
   const setField = (field: keyof SignUpForm) => (value: string) =>
     setForm(prev => ({ ...prev, [field]: value }));
 
-  // ── Submit form ───────────────────────────────────────────────────
+  // ── Submit form ───────────────────────────────────────────────────────────
 
   const handleRegister = async () => {
     const { firstName, lastName, dateOfBirth, email } = form;
@@ -232,14 +238,50 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
     setStatusMessage('Creating your account…');
     const result = await registerUser(form);
     setLoading(false);
+
+    if (result.success) {
+      setRegisteredEmail(form.email.trim().toLowerCase());
+      setIsError(false);
+      setStatusMessage('');
+      setStep('otp');
+    } else if (result.message === 'UNVERIFIED_ACCOUNT') {
+      // Unverified account exists — show continue prompt
+      setRegisteredEmail(form.email.trim().toLowerCase());
+      setIsError(false);
+      setStatusMessage('');
+      setStep('continue');
+    } else {
+      setIsError(true);
+      setStatusMessage(result.message);
+    }
+  };
+
+  // ── Continue signup — resend OTP and go to OTP step ──────────────────────
+
+  const handleContinueSignup = async () => {
+    setLoading(true);
+    setIsError(false);
+    setStatusMessage('Sending new code…');
+    const result = await resendSignUpOtp(registeredEmail);
+    setLoading(false);
     setIsError(!result.success);
     setStatusMessage(result.message);
     if (result.success) {
+      setOtp('');
       setStep('otp');
     }
   };
 
-  // ── Verify OTP ────────────────────────────────────────────────────
+  const handleStartFresh = () => {
+    // Go back to form with email cleared so user knows they need a different email
+    setStep('form');
+    setForm({ firstName: '', lastName: '', dateOfBirth: '', email: '' });
+    setRegisteredEmail('');
+    setStatusMessage('');
+    setIsError(false);
+  };
+
+  // ── Verify OTP ────────────────────────────────────────────────────────────
 
   const handleVerifyOtp = async () => {
     if (otp.length < 6) {
@@ -250,13 +292,25 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
     setLoading(true);
     setIsError(false);
     setStatusMessage('Verifying…');
-    const result = await verifySignUpOtp(form.email, otp);
+    const result = await verifySignUpOtp(registeredEmail, otp);
     setLoading(false);
     setIsError(!result.success);
     setStatusMessage(result.message);
+
     if (result.success) {
-      // Redirect to linking page
+      setRegisteredEmail('');
       router.replace('/linking' as any);
+    }
+
+    if (!result.success && result.message.includes('cancelled')) {
+      setTimeout(() => {
+        setStep('form');
+        setOtp('');
+        setForm({ firstName: '', lastName: '', dateOfBirth: '', email: '' });
+        setStatusMessage('');
+        setIsError(false);
+        setRegisteredEmail('');
+      }, 2000);
     }
   };
 
@@ -264,10 +318,11 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
     setLoading(true);
     setIsError(false);
     setStatusMessage('Resending code…');
-    const result = await resendSignUpOtp(form.email);
+    const result = await resendSignUpOtp(registeredEmail);
     setLoading(false);
     setIsError(!result.success);
     setStatusMessage(result.message);
+    if (result.success) setOtp('');
   };
 
   const handleBackToForm = () => {
@@ -275,6 +330,20 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
     setOtp('');
     setStatusMessage('');
     setIsError(false);
+  };
+
+  // ── Header text per step ──────────────────────────────────────────────────
+
+  const headerTitle = () => {
+    if (step === 'form') return 'Create Account';
+    if (step === 'otp') return 'Verify Email';
+    return 'Welcome Back';
+  };
+
+  const headerSubtitle = () => {
+    if (step === 'form') return 'Join to enjoy!';
+    if (step === 'otp') return `Enter the 6-digit code sent to ${registeredEmail}`;
+    return `We found an incomplete signup for ${registeredEmail}`;
   };
 
   return (
@@ -292,19 +361,15 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
       >
         {/* Header */}
         <View style={styles.header}>
-          <Text style={[styles.title, { color: theme.text }]}>
-            {step === 'form' ? 'Create Account' : 'Verify Email'}
-          </Text>
-          <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
-            {step === 'form'
-              ? 'Join to enjoy!'
-              : `Enter the 6-digit code sent to ${form.email}`}
-          </Text>
+          <Text style={[styles.title, { color: theme.text }]}>{headerTitle()}</Text>
+          <Text style={[styles.subtitle, { color: theme.textSecondary }]}>{headerSubtitle()}</Text>
         </View>
 
         {/* Single glass card */}
         <View style={[styles.glassCard, { borderColor: theme.backgroundSelected }]}>
-          {step === 'form' ? (
+
+          {/* ── Form step ── */}
+          {step === 'form' && (
             <>
               <View style={styles.formGrid}>
                 <GlassInput
@@ -352,7 +417,50 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
                 </Text>
               </TouchableOpacity>
             </>
-          ) : (
+          )}
+
+          {/* ── Continue step ── */}
+          {step === 'continue' && (
+            <>
+              <View style={styles.continueBox}>
+                <Text style={[styles.continueTitle, { color: theme.text }]}>
+                  You already started signing up.{'\n'}Continue?
+                </Text>
+                <Text style={[styles.continueSubtitle, { color: theme.textSecondary }]}>
+                  We'll send a new activation code to{'\n'}{registeredEmail}
+                </Text>
+              </View>
+
+              {statusMessage !== '' && (
+                <Text style={[styles.statusText, { color: isError ? '#E53E3E' : '#38A169' }]}>
+                  {statusMessage}
+                </Text>
+              )}
+
+              <TouchableOpacity
+                style={[styles.ctaButton, { opacity: loading ? 0.6 : 1 }]}
+                onPress={handleContinueSignup}
+                disabled={loading}
+                accessibilityLabel="Continue signup button"
+              >
+                <Text style={styles.ctaText}>
+                  {loading ? 'Sending…' : 'Resend OTP & Continue →'}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={handleStartFresh}
+                accessibilityLabel="Use different email"
+              >
+                <Text style={[styles.linkText, { color: theme.textSecondary }]}>
+                  Use a different email
+                </Text>
+              </TouchableOpacity>
+            </>
+          )}
+
+          {/* ── OTP step ── */}
+          {step === 'otp' && (
             <>
               <View style={styles.otpSection}>
                 <Text style={[inputStyles.label, { color: labelColor }]}>Activation Code</Text>
@@ -361,6 +469,10 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
                   borderColor={theme.backgroundSelected} textColor={theme.text}
                 />
               </View>
+
+              <Text style={[styles.hintText, { color: labelColor }]}>
+                Code expires in 5 minutes. If you don't receive it, tap Resend below.
+              </Text>
 
               {statusMessage !== '' && (
                 <Text style={[styles.statusText, { color: isError ? '#E53E3E' : '#38A169' }]}>
@@ -396,6 +508,7 @@ export default function SignUpScreen({ onNavigateToSignIn }: SignUpScreenProps) 
               </TouchableOpacity>
             </>
           )}
+
         </View>
 
         {/* Footer */}
@@ -444,7 +557,24 @@ const styles = StyleSheet.create({
     maxWidth: 600, width: '100%', alignSelf: 'center',
   },
   formGrid: { gap: Spacing.three },
+  continueBox: {
+    gap: Spacing.two,
+    alignItems: 'center',
+    paddingVertical: Spacing.two,
+  },
+  continueTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  continueSubtitle: {
+    fontSize: 13,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
   otpSection: { gap: Spacing.two },
+  hintText: { fontSize: 11, textAlign: 'center', opacity: 0.7 },
   statusText: { fontSize: 12, textAlign: 'center' },
   ctaButton: {
     borderRadius: 14, paddingVertical: 16,

--- a/server/src/main/java/com/multi_audio_platform/MultiAudioPlatformApplication.java
+++ b/server/src/main/java/com/multi_audio_platform/MultiAudioPlatformApplication.java
@@ -2,12 +2,12 @@ package com.multi_audio_platform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MultiAudioPlatformApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(MultiAudioPlatformApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(MultiAudioPlatformApplication.class, args);
+    }
 }

--- a/server/src/main/java/com/multi_audio_platform/controller/AuthController.java
+++ b/server/src/main/java/com/multi_audio_platform/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.multi_audio_platform.dto.OtpRequest;
 import com.multi_audio_platform.dto.OtpVerifyRequest;
 import com.multi_audio_platform.dto.RegisterRequest;
 import com.multi_audio_platform.dto.RegisterResponse;
-import com.multi_audio_platform.dto.SignInRequest;
 import com.multi_audio_platform.dto.SignInResponse;
 import com.multi_audio_platform.service.OtpService;
 import com.multi_audio_platform.service.UserService;
@@ -45,11 +44,18 @@ public class AuthController {
         return ResponseEntity.status(status).body(response);
     }
 
-    // ─── Sign In ──────────────────────────────────────────────────────────────
+    // ─── Sign In OTP ──────────────────────────────────────────────────────────
 
-    @PostMapping("/sign-in")
-    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest request) {
-        SignInResponse response = userService.signIn(request.getEmail());
+    @PostMapping("/send-otp")
+    public ResponseEntity<RegisterResponse> sendSignInOtp(@RequestBody OtpRequest request) {
+        RegisterResponse response = otpService.sendSignInOtp(request.getEmail());
+        int status = response.isSuccess() ? 200 : 400;
+        return ResponseEntity.status(status).body(response);
+    }
+
+    @PostMapping("/verify-otp")
+    public ResponseEntity<SignInResponse> verifySignInOtp(@RequestBody OtpVerifyRequest request) {
+        SignInResponse response = otpService.verifySignInOtp(request.getEmail(), request.getOtp());
         int status = response.isSuccess() ? 200 : 400;
         return ResponseEntity.status(status).body(response);
     }

--- a/server/src/main/java/com/multi_audio_platform/model/NavigationState.java
+++ b/server/src/main/java/com/multi_audio_platform/model/NavigationState.java
@@ -16,6 +16,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "navigation_state")
@@ -31,11 +33,11 @@ public class NavigationState {
     @OneToOne
     @MapsId
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonBackReference
     private User user;
 
     @Enumerated(EnumType.STRING)
     private CardType cardIdentifier;
     private LocalDateTime timestamp;
-    
 }

--- a/server/src/main/java/com/multi_audio_platform/model/User.java
+++ b/server/src/main/java/com/multi_audio_platform/model/User.java
@@ -41,6 +41,10 @@ public class User {
     @Builder.Default
     private Boolean linked = false;
 
+    @Column(name = "otp_attempts")
+    @Builder.Default
+    private Integer otpAttempts = 0;
+
     @Column(name = "verification_token")
     private String verificationToken;
 

--- a/server/src/main/java/com/multi_audio_platform/model/User.java
+++ b/server/src/main/java/com/multi_audio_platform/model/User.java
@@ -21,17 +21,24 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // Encrypted PII fields — stored as Base64 AES-256 ciphertext
     @Column(name = "first_name", nullable = false)
     private String firstName;
 
     @Column(name = "last_name", nullable = false)
     private String lastName;
 
+    // Stored as String to hold encrypted value (was LocalDate, now encrypted text)
     @Column(name = "date_of_birth", nullable = false)
-    private LocalDate dateOfBirth;
+    private String dateOfBirth;
 
+    // SHA-256 hash of email — used for fast lookups, cannot be reversed
     @Column(name = "email", nullable = false, unique = true)
     private String email;
+
+    // AES-256 encrypted email — used to display actual email back to user
+    @Column(name = "email_encrypted")
+    private String emailEncrypted;
 
     @Column(name = "verified")
     @Builder.Default

--- a/server/src/main/java/com/multi_audio_platform/repository/UserRepository.java
+++ b/server/src/main/java/com/multi_audio_platform/repository/UserRepository.java
@@ -2,8 +2,13 @@ package com.multi_audio_platform.repository;
 
 import com.multi_audio_platform.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +16,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     Optional<User> findByVerificationToken(String token);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM User u WHERE u.verified = false AND u.createdAt < :cutoff")
+    void deleteUnverifiedUsersOlderThan(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/server/src/main/java/com/multi_audio_platform/repository/UserRepository.java
+++ b/server/src/main/java/com/multi_audio_platform/repository/UserRepository.java
@@ -13,8 +13,9 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-    boolean existsByEmail(String email);
+    // email column now stores SHA-256 hash — pass hashed value to these methods
+    Optional<User> findByEmail(String emailHash);
+    boolean existsByEmail(String emailHash);
     Optional<User> findByVerificationToken(String token);
 
     @Modifying

--- a/server/src/main/java/com/multi_audio_platform/service/EncryptionService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/EncryptionService.java
@@ -77,7 +77,32 @@ public class EncryptionService {
     // ─── Helper ───────────────────────────────────────────────────────────────
 
     private SecretKey getSecretKey() {
-        byte[] keyBytes = Base64.getDecoder().decode(secretKeyBase64);
+        if (secretKeyBase64 == null || secretKeyBase64.trim().isEmpty()) {
+            throw new IllegalStateException(
+                    "Invalid encryption.secret.key configuration: value is missing or blank. " +
+                            "Expected Base64-encoded AES key bytes (16, 24, or 32 bytes; 32 bytes recommended for AES-256).");
+        }
+
+        final byte[] keyBytes;
+        try {
+            keyBytes = Base64.getDecoder().decode(secretKeyBase64);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException(
+                    "Invalid encryption.secret.key configuration: value is not valid Base64. " +
+                            "Expected Base64-encoded AES key bytes (16, 24, or 32 bytes; 32 bytes recommended for AES-256).",
+                    e);
+        }
+
+        if (!isValidAesKeyLength(keyBytes.length)) {
+            throw new IllegalStateException(
+                    "Invalid encryption.secret.key configuration: decoded key length is " + keyBytes.length +
+                            " bytes. AES keys must be 16, 24, or 32 bytes; use Base64 of 32 bytes for AES-256.");
+        }
+
         return new SecretKeySpec(keyBytes, "AES");
+    }
+
+    private boolean isValidAesKeyLength(int keyLengthBytes) {
+        return keyLengthBytes == 16 || keyLengthBytes == 24 || keyLengthBytes == 32;
     }
 }

--- a/server/src/main/java/com/multi_audio_platform/service/EncryptionService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/EncryptionService.java
@@ -1,0 +1,83 @@
+package com.multi_audio_platform.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Service
+public class EncryptionService {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
+
+    @Value("${encryption.secret.key}")
+    private String secretKeyBase64;
+
+    // ─── Encrypt ──────────────────────────────────────────────────────────────
+
+    public String encrypt(String plainText) {
+        if (plainText == null) return null;
+        try {
+            SecretKey key = getSecretKey();
+
+            // Generate random IV for each encryption
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+            byte[] encryptedData = cipher.doFinal(plainText.getBytes("UTF-8"));
+
+            // Prepend IV to encrypted data so we can use it for decryption
+            byte[] encryptedWithIv = new byte[GCM_IV_LENGTH + encryptedData.length];
+            System.arraycopy(iv, 0, encryptedWithIv, 0, GCM_IV_LENGTH);
+            System.arraycopy(encryptedData, 0, encryptedWithIv, GCM_IV_LENGTH, encryptedData.length);
+
+            return Base64.getEncoder().encodeToString(encryptedWithIv);
+        } catch (Exception e) {
+            throw new RuntimeException("Encryption failed", e);
+        }
+    }
+
+    // ─── Decrypt ──────────────────────────────────────────────────────────────
+
+    public String decrypt(String encryptedText) {
+        if (encryptedText == null) return null;
+        try {
+            SecretKey key = getSecretKey();
+
+            byte[] encryptedWithIv = Base64.getDecoder().decode(encryptedText);
+
+            // Extract IV from the first 12 bytes
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            System.arraycopy(encryptedWithIv, 0, iv, 0, GCM_IV_LENGTH);
+
+            // Extract the actual encrypted data
+            byte[] encryptedData = new byte[encryptedWithIv.length - GCM_IV_LENGTH];
+            System.arraycopy(encryptedWithIv, GCM_IV_LENGTH, encryptedData, 0, encryptedData.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+            byte[] decryptedData = cipher.doFinal(encryptedData);
+            return new String(decryptedData, "UTF-8");
+        } catch (Exception e) {
+            throw new RuntimeException("Decryption failed", e);
+        }
+    }
+
+    // ─── Helper ───────────────────────────────────────────────────────────────
+
+    private SecretKey getSecretKey() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKeyBase64);
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+}

--- a/server/src/main/java/com/multi_audio_platform/service/HashingService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/HashingService.java
@@ -1,0 +1,28 @@
+package com.multi_audio_platform.service;
+
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+@Service
+public class HashingService {
+
+    // ─── Hash email for database lookups ──────────────────────────────────────
+    // SHA-256 is one-way — cannot be reversed back to original email
+    // Always produces the same output for the same input, so queries work
+
+    public String hashEmail(String email) {
+        if (email == null) return null;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(
+                email.toLowerCase().trim().getBytes(StandardCharsets.UTF_8)
+            );
+            return Base64.getEncoder().encodeToString(hashBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("Hashing failed", e);
+        }
+    }
+}

--- a/server/src/main/java/com/multi_audio_platform/service/OtpService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/OtpService.java
@@ -124,9 +124,14 @@ public class OtpService {
         }
 
         // OTP correct — mark user as verified
-        User user = userRepository.findByEmail(emailHash)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        Optional<User> optionalUser = userRepository.findByEmail(emailHash);
+        if (optionalUser.isEmpty()) {
+            signUpOtpStore.remove(key);
+            return new RegisterResponse(false,
+                "Registration was not found or has expired. Please sign up again.", null);
+        }
 
+        User user = optionalUser.get();
         user.setVerified(true);
         user.setVerificationToken(null);
         user.setOtpAttempts(0);

--- a/server/src/main/java/com/multi_audio_platform/service/OtpService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/OtpService.java
@@ -54,10 +54,6 @@ public class OtpService {
             return new RegisterResponse(false, "Account is already verified. Please sign in.", null);
         }
 
-        // Reset attempts on resend
-        user.setOtpAttempts(0);
-        userRepository.save(user);
-
         String otp = generateOtp();
         LocalDateTime expiry = LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES);
         signUpOtpStore.put(key, new OtpEntry(otp, expiry));

--- a/server/src/main/java/com/multi_audio_platform/service/OtpService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/OtpService.java
@@ -1,6 +1,7 @@
 package com.multi_audio_platform.service;
 
 import com.multi_audio_platform.dto.RegisterResponse;
+import com.multi_audio_platform.dto.SignInResponse;
 import com.multi_audio_platform.model.CardType;
 import com.multi_audio_platform.model.NavigationState;
 import com.multi_audio_platform.model.User;
@@ -8,6 +9,7 @@ import com.multi_audio_platform.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
@@ -24,8 +26,10 @@ public class OtpService {
     private final JavaMailSender mailSender;
 
     private final Map<String, OtpEntry> signUpOtpStore = new ConcurrentHashMap<>();
+    private final Map<String, OtpEntry> signInOtpStore = new ConcurrentHashMap<>();
 
     private static final int OTP_EXPIRY_MINUTES = 5;
+    private static final int MAX_OTP_ATTEMPTS = 3;
 
     // ─── Send Sign Up OTP (for unverified users) ──────────────────────────────
 
@@ -45,10 +49,13 @@ public class OtpService {
 
         User user = optionalUser.get();
 
-        // Only send OTP to unverified users — this is for sign up activation
         if (Boolean.TRUE.equals(user.getVerified())) {
             return new RegisterResponse(false, "Account is already verified. Please sign in.", null);
         }
+
+        // Reset attempts when resending OTP
+        user.setOtpAttempts(0);
+        userRepository.save(user);
 
         String otp = generateOtp();
         LocalDateTime expiry = LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES);
@@ -89,24 +96,40 @@ public class OtpService {
 
         if (LocalDateTime.now().isAfter(entry.expiry())) {
             signUpOtpStore.remove(key);
-            return new RegisterResponse(false, "Code has expired. Please request a new one.", null);
+            return new RegisterResponse(false,
+                "Code has expired. Please click resend to get a new one.", null);
         }
 
         if (!entry.otp().equals(otp.trim())) {
+            Optional<User> optionalUser = userRepository.findByEmail(key);
+            if (optionalUser.isPresent()) {
+                User user = optionalUser.get();
+                int attempts = (user.getOtpAttempts() == null ? 0 : user.getOtpAttempts()) + 1;
+                user.setOtpAttempts(attempts);
+
+                if (attempts >= MAX_OTP_ATTEMPTS) {
+                    userRepository.delete(user);
+                    signUpOtpStore.remove(key);
+                    return new RegisterResponse(false,
+                        "Too many incorrect attempts. Your registration has been cancelled. Please sign up again.", null);
+                }
+
+                userRepository.save(user);
+                int remaining = MAX_OTP_ATTEMPTS - attempts;
+                return new RegisterResponse(false,
+                    "Incorrect code. " + remaining + " attempt(s) remaining.", null);
+            }
             return new RegisterResponse(false, "Incorrect code. Please try again.", null);
         }
 
-        // Mark user as verified
-        Optional<User> optionalUser = userRepository.findByEmail(key);
-        if (optionalUser.isEmpty()) {
-            return new RegisterResponse(false, "Account not found. Please sign up again.", null);
-        }
-        User user = optionalUser.get();
+        // OTP correct — mark user as verified
+        User user = userRepository.findByEmail(key)
+                .orElseThrow(() -> new RuntimeException("User not found"));
 
         user.setVerified(true);
         user.setVerificationToken(null);
+        user.setOtpAttempts(0);
 
-        // Initialize default NavigationState on first verification (from her version)
         if (user.getNavigationState() == null) {
             NavigationState initialState = NavigationState.builder()
                     .user(user)
@@ -120,6 +143,92 @@ public class OtpService {
         signUpOtpStore.remove(key);
 
         return new RegisterResponse(true, "Account activated successfully!", user.getId());
+    }
+
+    // ─── Send Sign In OTP (for verified users) ────────────────────────────────
+
+    public RegisterResponse sendSignInOtp(String email) {
+        if (email == null || email.isBlank()) {
+            return new RegisterResponse(false, "Please enter your email.", null);
+        }
+
+        if (!email.contains("@")) {
+            return new RegisterResponse(false, "Please enter a valid email address.", null);
+        }
+
+        Optional<User> optionalUser = userRepository.findByEmail(email.toLowerCase().trim());
+        if (optionalUser.isEmpty()) {
+            return new RegisterResponse(false, "No account found with this email.", null);
+        }
+
+        User user = optionalUser.get();
+
+        if (!Boolean.TRUE.equals(user.getVerified())) {
+            return new RegisterResponse(false,
+                "Your account is not verified. Please check your email for the activation code.", null);
+        }
+
+        String otp = generateOtp();
+        LocalDateTime expiry = LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES);
+        signInOtpStore.put(email.toLowerCase().trim(), new OtpEntry(otp, expiry));
+
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email);
+            message.setSubject("Your Multi-Audio Platform Sign-In Code");
+            message.setText(
+                "Hi " + user.getFirstName() + ",\n\n" +
+                "Your one-time sign-in code is: " + otp + "\n\n" +
+                "This code expires in " + OTP_EXPIRY_MINUTES + " minutes.\n\n" +
+                "If you didn't request this, please ignore this email.\n\n" +
+                "— The Multi-Audio Platform Team"
+            );
+            mailSender.send(message);
+        } catch (Exception e) {
+            return new RegisterResponse(false, "Failed to send OTP. Please try again.", null);
+        }
+
+        return new RegisterResponse(true, "OTP sent to " + email, null);
+    }
+
+    // ─── Verify Sign In OTP ───────────────────────────────────────────────────
+
+    public SignInResponse verifySignInOtp(String email, String otp) {
+        if (email == null || otp == null) {
+            return new SignInResponse(false, "Invalid request.", null, null);
+        }
+
+        String key = email.toLowerCase().trim();
+        OtpEntry entry = signInOtpStore.get(key);
+
+        if (entry == null) {
+            return new SignInResponse(false, "No OTP was sent to this email.", null, null);
+        }
+
+        if (LocalDateTime.now().isAfter(entry.expiry())) {
+            signInOtpStore.remove(key);
+            return new SignInResponse(false, "OTP has expired. Please request a new one.", null, null);
+        }
+
+        if (!entry.otp().equals(otp.trim())) {
+            return new SignInResponse(false, "Incorrect OTP. Please try again.", null, null);
+        }
+
+        signInOtpStore.remove(key);
+
+        User user = userRepository.findByEmail(key)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        String redirect = Boolean.TRUE.equals(user.getLinked()) ? "main" : "linking";
+        return new SignInResponse(true, "Signed in successfully!", redirect, user.getId());
+    }
+
+    // ─── Scheduled cleanup — runs every 5 minutes ─────────────────────────────
+
+    @Scheduled(fixedRate = 300000)
+    public void cleanUpUnverifiedUsers() {
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(15);
+        userRepository.deleteUnverifiedUsersOlderThan(cutoff);
     }
 
     // ─── Helper ───────────────────────────────────────────────────────────────

--- a/server/src/main/java/com/multi_audio_platform/service/OtpService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/OtpService.java
@@ -24,6 +24,8 @@ public class OtpService {
 
     private final UserRepository userRepository;
     private final JavaMailSender mailSender;
+    private final HashingService hashingService;
+    private final EncryptionService encryptionService;
 
     private final Map<String, OtpEntry> signUpOtpStore = new ConcurrentHashMap<>();
     private final Map<String, OtpEntry> signInOtpStore = new ConcurrentHashMap<>();
@@ -31,18 +33,17 @@ public class OtpService {
     private static final int OTP_EXPIRY_MINUTES = 5;
     private static final int MAX_OTP_ATTEMPTS = 3;
 
-    // ─── Send Sign Up OTP (for unverified users) ──────────────────────────────
+    // ─── Send Sign Up OTP ─────────────────────────────────────────────────────
 
-    public RegisterResponse sendSignUpOtp(String email) {
-        if (email == null || email.isBlank()) {
+    public RegisterResponse sendSignUpOtp(String rawEmail) {
+        if (rawEmail == null || rawEmail.isBlank()) {
             return new RegisterResponse(false, "Please enter your email.", null);
         }
 
-        if (!email.contains("@")) {
-            return new RegisterResponse(false, "Please enter a valid email address.", null);
-        }
+        String key = rawEmail.toLowerCase().trim();
+        String emailHash = hashingService.hashEmail(key);
 
-        Optional<User> optionalUser = userRepository.findByEmail(email.toLowerCase().trim());
+        Optional<User> optionalUser = userRepository.findByEmail(emailHash);
         if (optionalUser.isEmpty()) {
             return new RegisterResponse(false, "No account found with this email.", null);
         }
@@ -53,20 +54,23 @@ public class OtpService {
             return new RegisterResponse(false, "Account is already verified. Please sign in.", null);
         }
 
-        // Reset attempts when resending OTP
+        // Reset attempts on resend
         user.setOtpAttempts(0);
         userRepository.save(user);
 
         String otp = generateOtp();
         LocalDateTime expiry = LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES);
-        signUpOtpStore.put(email.toLowerCase().trim(), new OtpEntry(otp, expiry));
+        signUpOtpStore.put(key, new OtpEntry(otp, expiry));
+
+        // Decrypt first name for email greeting
+        String firstName = encryptionService.decrypt(user.getFirstName());
 
         try {
             SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(email);
+            message.setTo(key);
             message.setSubject("Activate your Multi-Audio Platform account");
             message.setText(
-                "Hi " + user.getFirstName() + ",\n\n" +
+                "Hi " + firstName + ",\n\n" +
                 "Your account activation code is: " + otp + "\n\n" +
                 "This code expires in " + OTP_EXPIRY_MINUTES + " minutes.\n\n" +
                 "If you didn't create an account, you can safely ignore this email.\n\n" +
@@ -77,17 +81,18 @@ public class OtpService {
             return new RegisterResponse(false, "Failed to send OTP. Please try again.", null);
         }
 
-        return new RegisterResponse(true, "Activation code sent to " + email, null);
+        return new RegisterResponse(true, "Activation code sent to " + key, null);
     }
 
     // ─── Verify Sign Up OTP ───────────────────────────────────────────────────
 
-    public RegisterResponse verifySignUpOtp(String email, String otp) {
-        if (email == null || otp == null) {
+    public RegisterResponse verifySignUpOtp(String rawEmail, String otp) {
+        if (rawEmail == null || otp == null) {
             return new RegisterResponse(false, "Invalid request.", null);
         }
 
-        String key = email.toLowerCase().trim();
+        String key = rawEmail.toLowerCase().trim();
+        String emailHash = hashingService.hashEmail(key);
         OtpEntry entry = signUpOtpStore.get(key);
 
         if (entry == null) {
@@ -101,7 +106,7 @@ public class OtpService {
         }
 
         if (!entry.otp().equals(otp.trim())) {
-            Optional<User> optionalUser = userRepository.findByEmail(key);
+            Optional<User> optionalUser = userRepository.findByEmail(emailHash);
             if (optionalUser.isPresent()) {
                 User user = optionalUser.get();
                 int attempts = (user.getOtpAttempts() == null ? 0 : user.getOtpAttempts()) + 1;
@@ -123,7 +128,7 @@ public class OtpService {
         }
 
         // OTP correct — mark user as verified
-        User user = userRepository.findByEmail(key)
+        User user = userRepository.findByEmail(emailHash)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         user.setVerified(true);
@@ -145,18 +150,21 @@ public class OtpService {
         return new RegisterResponse(true, "Account activated successfully!", user.getId());
     }
 
-    // ─── Send Sign In OTP (for verified users) ────────────────────────────────
+    // ─── Send Sign In OTP ─────────────────────────────────────────────────────
 
-    public RegisterResponse sendSignInOtp(String email) {
-        if (email == null || email.isBlank()) {
+    public RegisterResponse sendSignInOtp(String rawEmail) {
+        if (rawEmail == null || rawEmail.isBlank()) {
             return new RegisterResponse(false, "Please enter your email.", null);
         }
 
-        if (!email.contains("@")) {
+        if (!rawEmail.contains("@")) {
             return new RegisterResponse(false, "Please enter a valid email address.", null);
         }
 
-        Optional<User> optionalUser = userRepository.findByEmail(email.toLowerCase().trim());
+        String key = rawEmail.toLowerCase().trim();
+        String emailHash = hashingService.hashEmail(key);
+
+        Optional<User> optionalUser = userRepository.findByEmail(emailHash);
         if (optionalUser.isEmpty()) {
             return new RegisterResponse(false, "No account found with this email.", null);
         }
@@ -170,14 +178,16 @@ public class OtpService {
 
         String otp = generateOtp();
         LocalDateTime expiry = LocalDateTime.now().plusMinutes(OTP_EXPIRY_MINUTES);
-        signInOtpStore.put(email.toLowerCase().trim(), new OtpEntry(otp, expiry));
+        signInOtpStore.put(key, new OtpEntry(otp, expiry));
+
+        String firstName = encryptionService.decrypt(user.getFirstName());
 
         try {
             SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(email);
+            message.setTo(key);
             message.setSubject("Your Multi-Audio Platform Sign-In Code");
             message.setText(
-                "Hi " + user.getFirstName() + ",\n\n" +
+                "Hi " + firstName + ",\n\n" +
                 "Your one-time sign-in code is: " + otp + "\n\n" +
                 "This code expires in " + OTP_EXPIRY_MINUTES + " minutes.\n\n" +
                 "If you didn't request this, please ignore this email.\n\n" +
@@ -188,17 +198,17 @@ public class OtpService {
             return new RegisterResponse(false, "Failed to send OTP. Please try again.", null);
         }
 
-        return new RegisterResponse(true, "OTP sent to " + email, null);
+        return new RegisterResponse(true, "OTP sent to " + key, null);
     }
 
     // ─── Verify Sign In OTP ───────────────────────────────────────────────────
 
-    public SignInResponse verifySignInOtp(String email, String otp) {
-        if (email == null || otp == null) {
+    public SignInResponse verifySignInOtp(String rawEmail, String otp) {
+        if (rawEmail == null || otp == null) {
             return new SignInResponse(false, "Invalid request.", null, null);
         }
 
-        String key = email.toLowerCase().trim();
+        String key = rawEmail.toLowerCase().trim();
         OtpEntry entry = signInOtpStore.get(key);
 
         if (entry == null) {
@@ -216,14 +226,15 @@ public class OtpService {
 
         signInOtpStore.remove(key);
 
-        User user = userRepository.findByEmail(key)
+        String emailHash = hashingService.hashEmail(key);
+        User user = userRepository.findByEmail(emailHash)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         String redirect = Boolean.TRUE.equals(user.getLinked()) ? "main" : "linking";
         return new SignInResponse(true, "Signed in successfully!", redirect, user.getId());
     }
 
-    // ─── Scheduled cleanup — runs every 5 minutes ─────────────────────────────
+    // ─── Scheduled cleanup ────────────────────────────────────────────────────
 
     @Scheduled(fixedRate = 300000)
     public void cleanUpUnverifiedUsers() {

--- a/server/src/main/java/com/multi_audio_platform/service/UserService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/UserService.java
@@ -34,7 +34,19 @@ public class UserService {
             return new RegisterResponse(false, "Please enter a valid email address.", null);
         }
 
-        if (userRepository.existsByEmail(request.getEmail().toLowerCase().trim())) {
+        String email = request.getEmail().toLowerCase().trim();
+
+        // Check if email already exists
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            // If unverified — let frontend know to show "continue signup" prompt
+            if (!Boolean.TRUE.equals(user.getVerified())) {
+                return new RegisterResponse(false, "UNVERIFIED_ACCOUNT", user.getId());
+            }
+
+            // If verified — normal duplicate error
             return new RegisterResponse(false, "An account with this email already exists.", null);
         }
 
@@ -51,7 +63,7 @@ public class UserService {
                 .firstName(request.getFirstName().trim())
                 .lastName(request.getLastName().trim())
                 .dateOfBirth(dob)
-                .email(request.getEmail().toLowerCase().trim())
+                .email(email)
                 .verified(false)
                 .linked(false)
                 .build();
@@ -60,7 +72,7 @@ public class UserService {
 
         RegisterResponse otpResult = otpService.sendSignUpOtp(user.getEmail());
         if (!otpResult.isSuccess()) {
-            return new RegisterResponse(false,
+            return new RegisterResponse(true,
                 "Account created but we couldn't send the activation code. Please contact support.",
                 user.getId());
         }
@@ -74,27 +86,26 @@ public class UserService {
 
     public SignInResponse signIn(String email) {
         if (email == null || email.isBlank()) {
-            return new SignInResponse(false, "Please enter your email.", null,null);
+            return new SignInResponse(false, "Please enter your email.", null, null);
         }
 
         if (!email.contains("@")) {
-            return new SignInResponse(false, "Please enter a valid email address.", null,null);
+            return new SignInResponse(false, "Please enter a valid email address.", null, null);
         }
 
         Optional<User> optionalUser = userRepository.findByEmail(email.toLowerCase().trim());
 
         if (optionalUser.isEmpty()) {
-            return new SignInResponse(false, "No account found with this email.", null,null);
+            return new SignInResponse(false, "No account found with this email.", null, null);
         }
 
         User user = optionalUser.get();
 
         if (!Boolean.TRUE.equals(user.getVerified())) {
             return new SignInResponse(false,
-                "Your account is not verified. Please check your email for the activation code.", null,null);
+                "Your account is not verified. Please check your email for the activation code.", null, null);
         }
 
-        // Redirect based on whether user has linked a service
         if (!Boolean.TRUE.equals(user.getLinked())) {
             return new SignInResponse(true, "Welcome back, " + user.getFirstName() + "!", "linking", user.getId());
         }

--- a/server/src/main/java/com/multi_audio_platform/service/UserService.java
+++ b/server/src/main/java/com/multi_audio_platform/service/UserService.java
@@ -8,9 +8,6 @@ import com.multi_audio_platform.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 @Service
@@ -19,6 +16,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final OtpService otpService;
+    private final EncryptionService encryptionService;
+    private final HashingService hashingService;
 
     // ─── Register ─────────────────────────────────────────────────────────────
 
@@ -34,43 +33,39 @@ public class UserService {
             return new RegisterResponse(false, "Please enter a valid email address.", null);
         }
 
-        String email = request.getEmail().toLowerCase().trim();
+        String rawEmail = request.getEmail().toLowerCase().trim();
+        String emailHash = hashingService.hashEmail(rawEmail);
 
-        // Check if email already exists
-        Optional<User> existingUser = userRepository.findByEmail(email);
+        // Check if email already exists using hash
+        Optional<User> existingUser = userRepository.findByEmail(emailHash);
         if (existingUser.isPresent()) {
             User user = existingUser.get();
-
-            // If unverified — let frontend know to show "continue signup" prompt
             if (!Boolean.TRUE.equals(user.getVerified())) {
                 return new RegisterResponse(false, "UNVERIFIED_ACCOUNT", user.getId());
             }
-
-            // If verified — normal duplicate error
             return new RegisterResponse(false, "An account with this email already exists.", null);
         }
 
-        LocalDate dob;
-        try {
-            String cleaned = request.getDateOfBirth().replace(" ", "");
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-            dob = LocalDate.parse(cleaned, formatter);
-        } catch (DateTimeParseException e) {
+        // Validate date format before encrypting
+        if (!request.getDateOfBirth().matches("\\d{2}/\\d{2}/\\d{4}")) {
             return new RegisterResponse(false, "Invalid date format. Use DD/MM/YYYY.", null);
         }
 
+        // Encrypt PII before saving
         User user = User.builder()
-                .firstName(request.getFirstName().trim())
-                .lastName(request.getLastName().trim())
-                .dateOfBirth(dob)
-                .email(email)
+                .firstName(encryptionService.encrypt(request.getFirstName().trim()))
+                .lastName(encryptionService.encrypt(request.getLastName().trim()))
+                .dateOfBirth(encryptionService.encrypt(request.getDateOfBirth().trim()))
+                .email(emailHash)
+                .emailEncrypted(encryptionService.encrypt(rawEmail))
                 .verified(false)
                 .linked(false)
                 .build();
 
         userRepository.save(user);
 
-        RegisterResponse otpResult = otpService.sendSignUpOtp(user.getEmail());
+        // Send OTP using the raw email (decrypted)
+        RegisterResponse otpResult = otpService.sendSignUpOtp(rawEmail);
         if (!otpResult.isSuccess()) {
             return new RegisterResponse(true,
                 "Account created but we couldn't send the activation code. Please contact support.",
@@ -78,7 +73,7 @@ public class UserService {
         }
 
         return new RegisterResponse(true,
-            "Account created! Please enter the code sent to " + user.getEmail(),
+            "Account created! Please enter the code sent to " + rawEmail,
             user.getId());
     }
 
@@ -93,7 +88,9 @@ public class UserService {
             return new SignInResponse(false, "Please enter a valid email address.", null, null);
         }
 
-        Optional<User> optionalUser = userRepository.findByEmail(email.toLowerCase().trim());
+        // Hash the email for lookup
+        String emailHash = hashingService.hashEmail(email.toLowerCase().trim());
+        Optional<User> optionalUser = userRepository.findByEmail(emailHash);
 
         if (optionalUser.isEmpty()) {
             return new SignInResponse(false, "No account found with this email.", null, null);
@@ -107,15 +104,22 @@ public class UserService {
         }
 
         if (!Boolean.TRUE.equals(user.getLinked())) {
-            return new SignInResponse(true, "Welcome back, " + user.getFirstName() + "!", "linking", user.getId());
+            return new SignInResponse(true, "Welcome back!", "linking", user.getId());
         }
 
-        return new SignInResponse(true, "Welcome back, " + user.getFirstName() + "!", "main", user.getId());
+        return new SignInResponse(true, "Welcome back!", "main", user.getId());
     }
 
     // ─── Get User By ID ───────────────────────────────────────────────────────
+    // Decrypts PII before returning to frontend
 
     public Optional<User> getUserById(Long id) {
-        return userRepository.findById(id);
+        return userRepository.findById(id).map(user -> {
+            user.setFirstName(encryptionService.decrypt(user.getFirstName()));
+            user.setLastName(encryptionService.decrypt(user.getLastName()));
+            user.setDateOfBirth(encryptionService.decrypt(user.getDateOfBirth()));
+            user.setEmailEncrypted(encryptionService.decrypt(user.getEmailEncrypted()));
+            return user;
+        });
     }
 }

--- a/server/src/main/resources/application-local.properties.example
+++ b/server/src/main/resources/application-local.properties.example
@@ -4,3 +4,4 @@ DB_PASSWORD=provided_password
 APP_BASE_URL=http://localhost:8080
 MAIL_USERNAME=provided_mail_username
 MAIL_PASSWORD=provided_mail_password
+ENCRYPTION_SECRET_KEY=provided_key

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -22,3 +22,6 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
 app.base.url=${APP_BASE_URL}
+
+# Encryption
+encryption.secret.key=${ENCRYPTION_SECRET_KEY}


### PR DESCRIPTION
## Updated signin/signup 

- Change the Signin back with OTP.
- Add unverified status in the database.
- Backend will detect if an unverified user with the same email trying to signup, the system will pop up continuing signup message and direct the user to OTP page.
- Three wrong OTP attempts during signup, the system will automatically delete the user information from the Database.
- 15 mins after a user trying to signup but didn't enter the OTP code, the system will automatically delete the user information from the Database.

## Database Encryption
- AES-256 encrypt/decrypt for name, dateofbirth, emailencrypted.
- SHA-256 one-way hash for email lookup.
- Add emailencrypted field in database.
- Change email field in database to store hash.
- Encrypt on save, decrypt on read.
- Neon pgcrypto as second layer security measure at database level
- Add encryption key to applications.properties.
- Delete all old User and Navigatiostate in the database.

***For the Encyption Key, please add ''ENCRYPTION_SECRET_KEY=(provided in Discord chat)'' in your own application-local.properties.***

***Instructions for Encryption Key has also been added to Readme***
